### PR TITLE
Fix compile error:

### DIFF
--- a/cmake/genjava-extras.cmake.em
+++ b/cmake/genjava-extras.cmake.em
@@ -52,14 +52,16 @@ macro(_generate_module_java ARG_PKG ARG_GEN_OUTPUT_DIR ARG_GENERATED_FILES)
     # So we leave this dropping to inform it when gradle needs to run so that we can skip by
     # without the huge latency whenever we don't.
     set(DROPPINGS_FILE "${GRADLE_BUILD_DIR}/${ARG_PKG}/droppings")
-    add_custom_command(OUTPUT ${GRADLE_BUILD_FILE}
+    if ( NOT "${ARG_GENERATED_FILES}" STREQUAL "" )
+      add_custom_command(OUTPUT ${GRADLE_BUILD_FILE}
         DEPENDS ${GENJAVA_BIN} ${ARG_GENERATED_FILES}
         COMMAND ${CATKIN_ENV} ${PYTHON_EXECUTABLE} ${GENJAVA_BIN}
             -o ${GRADLE_BUILD_DIR}
             -p ${ARG_PKG}
         COMMAND touch ${DROPPINGS_FILE}
         COMMENT "Generating Java gradle project from ${ARG_PKG}"
-    )
+        )
+    endif()
 
     ################################
     # Compile Gradle Subproject

--- a/src/genjava/gradle_project.py
+++ b/src/genjava/gradle_project.py
@@ -116,14 +116,21 @@ def create_msg_package_index():
     # this is inconvenient since it would always mean we should bump the version number in an overlay
     # when all that is necessary is for it to recognise that it is in an overlay
     # ros_paths = rospkg.get_ros_paths()
+
+    r = rospkg.RosPack()
+
     package_index = {}
     ros_paths = rospkg.get_ros_package_path()
     ros_paths = [x for x in ros_paths.split(':') if x]
     # packages that don't properly identify themselves as message packages (fix upstream).
     for path in reversed(ros_paths):  # make sure we pick up the source overlays last
         for unused_package_path, package in find_packages(path).items():
-            if ('message_generation' in [dep.name for dep in package.build_depends] or
-                'genmsg' in [dep.name for dep in package.build_depends] or
+            try:
+                depends = r.get_depends(package.name)
+            except : # get_depends fails for metapackage
+                depends = []
+            if ('message_generation' in depends or
+                'genmsg' in depends or
                 package.name in rosjava_build_tools.catkin.message_package_whitelist):
 #                 print(package.name)
 #                 print("  version: %s" % package.version)


### PR DESCRIPTION
genjava failed to compile in

1) if there is depends to message_generation but no message ware set, pr2_2dnav and pr2_2dnav_slam 
2) if there is implict depends to message_generation 

, which are reporeted on https://github.com/jsk-ros-pkg/jsk_visualization/issues/551#issuecomment-165996226

to check case 1) You can download https://github.com/PR2/pr2_navigation_apps package 

to check case 2) you can check this with 1.0.27 of https://github.com/jsk-ros-pkg/jsk_visualization, or
if you change 'message_generaion' to one of output of `rospack depends-on message_generation`, say 'nodelet'
- gradle_project.py: run genjava if the package depends on message_generation/genmsg implicitly
- genjava-extras.camke.em: do not run genjava when three is no message to build
