### PR TITLE
Fix: message_generation dependency for standard messages

### DIFF
--- a/src/genjava/templates/genjava_project/build.gradle.in
+++ b/src/genjava/templates/genjava_project/build.gradle.in
@@ -33,7 +33,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath group: 'org.ros.rosjava_bootstrap', name: 'gradle_plugins', version: '[0.2,0.3)'
+        classpath group: 'org.ros.rosjava_bootstrap', name: 'gradle_plugins', version: '[0.3,0.4)'
     }
 }
 
@@ -56,7 +56,7 @@ task generateSources (type: JavaExec) {
 }
 
 dependencies {
-    compile 'org.ros.rosjava_bootstrap:message_generation:[0.2,0.3)'
+    compile 'org.ros.rosjava_bootstrap:message_generation:[0.3,0.4)'
     %(msg_dependencies)s
 }
 


### PR DESCRIPTION
This fix updates message_generation dependency to kinetic range in template to generate messages properly.

See https://github.com/rosjava/rosjava_mvn_repo/issues/27 and https://github.com/rosjava/rosjava_mvn_repo/issues/32.

For the record, I verified that messages are now generated with a dependency on message_generation from [0.3, 0.4) instead of [0.2, 0.3).

Example POM for a message generated with new template:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>org.ros.rosjava_messages</groupId>
  <artifactId>geometry_msgs</artifactId>
  <version>1.11.9</version>
  <dependencies>
    <dependency>
      <groupId>org.ros.rosjava_bootstrap</groupId>
      <artifactId>message_generation</artifactId>
      <version>[0.3,0.4)</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.ros.rosjava_messages</groupId>
      <artifactId>std_msgs</artifactId>
      <version>0.5.10</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
</project>
```

